### PR TITLE
Add an option to force writing to stdout

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,10 @@ environment variable REP_PAGER can be used to override the pager.
     /// Disable color
     pub no_color: bool,
 
+    #[structopt(long = "stdout")]
+    /// Force printing to standard output without using a pager
+    pub stdout: bool,
+
     #[structopt(short = "f", long = "flags", verbatim_doc_comment)]
     #[rustfmt::skip]
     /** Regex flags. May be combined (like `-f mc`)

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,15 +11,19 @@ impl App {
         Self { replacer }
     }
 
-    pub(crate) fn run(&self, preview: bool, delete: bool, color: bool, pager: Option<String>) -> Result<()> {
+    pub(crate) fn run(&self, preview: bool, delete: bool, color: bool, stdout: bool, pager: Option<String>) -> Result<()> {
         {
             let stdin = std::io::stdin();
             let handle = stdin.lock();
 
             // FIXME: Instantiating `output_type` and `write` should only happen if `preview` is true
-            let mut output_type = match OutputType::for_pager(pager, true) {
-                Ok(output_type) => output_type,
-                Err(_) => return Ok(()), // FIXME:
+            let mut output_type = if stdout {
+                OutputType::stdout()
+            } else {
+                match OutputType::for_pager(pager, true) {
+                    Ok(output_type) => output_type,
+                    Err(_) => return Ok(()), // FIXME:
+                }
             };
 
             let write = match output_type.handle() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,9 @@ fn main() -> Result<()> {
                 options.replacements,
             )?),
         )
-        .run(!options.write, options.delete, color, pager)?;
+        .run(!options.write, options.delete, color, options.stdout, pager)?;
     } else {
-        App::new(None).run(!options.write, options.delete, color, pager)?;
+        App::new(None).run(!options.write, options.delete, color, options.stdout, pager)?;
     }
 
     process::exit(0);

--- a/src/output.rs
+++ b/src/output.rs
@@ -68,7 +68,7 @@ impl OutputType {
         })
     }
 
-    fn stdout() -> Self {
+    pub fn stdout() -> Self {
         OutputType::Stdout(io::stdout())
     }
 


### PR DESCRIPTION
This comes from [this HN thread][1].

Since `rep` always opens a pager (except for one page?), it interferes with the editor opening at the same time.

So I added `--stdout` to force `rep` to output to `stdout`.

This PR may not be great. I am not a Rust programmer, and I admit that I did it in the dumbest way possible.

I'm open to harsh criticism here since this is my first public contribution using Rust. This includes criticism about how I implemented this.

I also tried running `rustfmt`, but it screamed about being deprecated. I tried installing `rustfmt-nightly`, and it failed. So if style is wrong, I'm sorry, and I'll fix it manually.

[1]: https://news.ycombinator.com/item?id=38816306