### PR TITLE
Bump lockfile version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "rep-grep"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "ansi_term",
  "anyhow",


### PR DESCRIPTION
The Cargo.toml and Cargo.lock are out of sync. This creates an issue when attempting to build the output while locked:

```
cargo build --locked
    Updating crates.io index
error: the lock file Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

Building while locked is important for some tooling, such as packaging with Nix. To fix this, just need to run `cargo update -w`.