### PR TITLE
Remove `#[cfg(not(rep_cross_compile))]`

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-#[cfg(not(rep_cross_compile))] // Cross-compilation does not allow to spawn threads but `command.assert()` would do.
 
 mod cli {
     use anyhow::Result;


### PR DESCRIPTION
This is a hold-over from the original `chmln/sd` and it's causing a
warning and we're not sure if it's still needed.

If it is needed, an alternative fix:

```
diff --git a/build.rs b/build.rs
index 7b3680b..c2fe66a 100644
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
 include!("src/cli.rs");

 fn main() {
+    // Inform Cargo/rustc about the custom cfg used in tests so `check-cfg` lints
+    // (which run during `cargo test`) don't warn about `rep_cross_compile`.
+    // See https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
+    println!("cargo:rustc-check-cfg=cfg(rep_cross_compile)");
     use std::{env::var, fs, str::FromStr};
     use structopt::clap::Shell;

```
